### PR TITLE
Remove text_model.embeddings.position_ids for newer transformer

### DIFF
--- a/library/model_util.py
+++ b/library/model_util.py
@@ -643,7 +643,7 @@ def convert_ldm_clip_checkpoint_v2(checkpoint, max_length):
             new_sd[key_pfx + "k_proj" + key_suffix] = values[1]
             new_sd[key_pfx + "v_proj" + key_suffix] = values[2]
 
-    # remove position_ids
+    # remove position_ids for newer transformer, which causes error :(
     if "text_model.encoder.text_model.embeddings.position_ids" in new_sd:
         # waifu diffusion v1.4
         new_sd.pop("text_model.encoder.text_model.embeddings.position_ids")

--- a/library/model_util.py
+++ b/library/model_util.py
@@ -643,16 +643,14 @@ def convert_ldm_clip_checkpoint_v2(checkpoint, max_length):
             new_sd[key_pfx + "k_proj" + key_suffix] = values[1]
             new_sd[key_pfx + "v_proj" + key_suffix] = values[2]
 
-    # rename or add position_ids
-    ANOTHER_POSITION_IDS_KEY = "text_model.encoder.text_model.embeddings.position_ids"
-    if ANOTHER_POSITION_IDS_KEY in new_sd:
+    # remove position_ids
+    if "text_model.encoder.text_model.embeddings.position_idss" in new_sd:
         # waifu diffusion v1.4
-        position_ids = new_sd[ANOTHER_POSITION_IDS_KEY]
-        del new_sd[ANOTHER_POSITION_IDS_KEY]
-    else:
-        position_ids = torch.Tensor([list(range(max_length))]).to(torch.int64)
+        new_sd.pop("text_model.encoder.text_model.embeddings.position_idss")
 
-    new_sd["text_model.embeddings.position_ids"] = position_ids
+    if "text_model.embeddings.position_ids" in new_sd:
+        new_sd.pop("text_model.embeddings.position_ids")
+
     return new_sd
 
 

--- a/library/model_util.py
+++ b/library/model_util.py
@@ -644,9 +644,9 @@ def convert_ldm_clip_checkpoint_v2(checkpoint, max_length):
             new_sd[key_pfx + "v_proj" + key_suffix] = values[2]
 
     # remove position_ids
-    if "text_model.encoder.text_model.embeddings.position_idss" in new_sd:
+    if "text_model.encoder.text_model.embeddings.position_ids" in new_sd:
         # waifu diffusion v1.4
-        new_sd.pop("text_model.encoder.text_model.embeddings.position_idss")
+        new_sd.pop("text_model.encoder.text_model.embeddings.position_ids")
 
     if "text_model.embeddings.position_ids" in new_sd:
         new_sd.pop("text_model.embeddings.position_ids")


### PR DESCRIPTION
CLIPTextModelの構造と変遷を何も知らないので、削除していいものなのかわからないけれど、SDv2モデルを`train_network.py`で、`transformer>=4.30.2`に読み込ませるには消す以外に方法がわからない。

`convert_ldm_clip_checkpoint_v1`には削除する実装がすでにある。

https://github.com/kohya-ss/sd-scripts/blob/e5ac09574928ec02fba5fe78267764d26bb7faa6/library/model_util.py#L575-L577

`convert_ldm_clip_checkpoint_v2`にはない（現状の確認）。この違いが手が回っていないだけなのか、意図的に残しているのかはわからないけれど、このPRでとりあえず動くようにする。

## 関連Issue

- https://github.com/aoirint/sd-scripts-docker/releases/tag/20241230.1
- https://github.com/kohya-ss/sd-scripts/issues/937
- https://github.com/kohya-ss/sd-scripts/pull/687
- https://github.com/kohya-ss/sd-scripts/pull/29
- https://github.com/open-mmlab/PIA/issues/13